### PR TITLE
Removed Python 2 backward compatibility

### DIFF
--- a/Shotwell_event2folder.py
+++ b/Shotwell_event2folder.py
@@ -24,7 +24,6 @@ class EmptyStringError(ValueError):
 
 
 # ------- Set Environment ---------
-os.stat_float_times (False)  #  So you won't get milliseconds retrieving Stat dates; this will raise in error parsing getmtime.
 gi.require_version('GExiv2', '0.10')  # user to avoid Gi warning
 
 # ------- Set Variables ---------


### PR DESCRIPTION
The os.stat_float_times() function has been removed.
It was introduced in Python 2.3 for backward compatibility with Python 2.2,
and was deprecated since Python 3.1.
See https://docs.python.org/3/whatsnew/3.7.html

Required for Ubuntu 20.04.

Signed-off-by: Christian Scheurer <git@tinytux.ch>